### PR TITLE
add protection in itemExists util for when obj is falsey

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@companydotcom/company-skynet-core",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "description": "Company.com Skynet core library",
   "main": "dist/index.js",
   "scripts": {

--- a/src/library/util.js
+++ b/src/library/util.js
@@ -112,6 +112,6 @@ export const sleep = async s => new Promise(r => setTimeout(() => { r(); }, s));
  * @returns {Boolean}
  */
 // eslint-disable-next-line max-len
-export const itemExists = (obj, param) => Object.prototype.hasOwnProperty.call(
+export const itemExists = (obj, param) => typeof obj === 'object' && obj !== null ? Object.prototype.hasOwnProperty.call(
   obj, param,
-);
+) : false;


### PR DESCRIPTION
in /process.js a fatal error was thrown when worker responded with error because procRes.workerResp was undefined.

Correct by having itemExists return false when the parent obj is not a obj or is null.